### PR TITLE
added real MD5 checking, made it multithreaded

### DIFF
--- a/beyond-melee-installer/MainWindow.xaml
+++ b/beyond-melee-installer/MainWindow.xaml
@@ -100,10 +100,10 @@
 
             <Button x:Name="dm" Content="Patch ISO!" HorizontalAlignment="Left" VerticalAlignment="Top" FontFamily="{StaticResource Montserrat}" Click="patch_Click" Grid.Row="1" Margin="108,410,0,0" Grid.Column="2"/>
 
-            <Border BorderThickness="10" Opacity="0.9" CornerRadius="6" Grid.Row="1" Margin="15,449,20,4" BorderBrush="Black">
+            <Border BorderThickness="10" Opacity="0.9" CornerRadius="6" Grid.Row="1" Margin="19,420,16,33" BorderBrush="Black">
                 <Rectangle Fill="#000000" Stretch="UniformToFill" ClipToBounds="True" Grid.ColumnSpan="3" Margin="0,0,-1,0"/>
             </Border>
-            <TextBlock FontFamily="{StaticResource Montserrat}" FontSize="12" Text="Patcher by cynthetic - @cyntheticTV" Margin="19,452,8,4" Grid.Row="1" Width="240" Height="20"/>
+            <TextBlock FontFamily="{StaticResource Montserrat}" FontSize="12" Text="Patcher by cynthetic - @cyntheticTV" Margin="19,423,8,33" Grid.Row="1" Width="240" Height="20"/>
 
         </Grid>
     </StackPanel>

--- a/beyond-melee-installer/MainWindow.xaml
+++ b/beyond-melee-installer/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
     	ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
-        Title="Beyond Melee Patcher v0.1.2-offline" Height="610" Width="800">
+        Title="Beyond Melee Patcher v0.2.0-offline" Height="610" Width="800">
     <Window.Resources>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="White"/>

--- a/beyond-melee-installer/MainWindow.xaml.cs
+++ b/beyond-melee-installer/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Security.Cryptography;
 using System.Windows.Media.Imaging;
@@ -19,7 +20,9 @@ namespace beyond_melee_installer
 
         private string filePath = "";
 
-        private readonly string versionNumber = "1-0-4";
+        private readonly string versionNumber = "1-1-1";
+
+        private readonly BackgroundWorker worker = new BackgroundWorker();
 
         //private Uri deltaUri = new Uri("pack://application:,,,/Resources/Patch.xdelta");
 
@@ -34,54 +37,39 @@ namespace beyond_melee_installer
             {
                 string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
 
-                string md5 = GetMD5(files[0]);
+                if (files.Length > 1)
+                {
+                    FileNameLabel.Text = string.Empty;
+                    FileNameLabel2.Foreground = Brushes.Red;
+                    FileNameLabel2.Text = "Please only drop one file in the window at a time.";
+                    LinkText.Text = string.Empty;
+                }
 
-                if (!Path.GetFileName(files[0]).Contains(".iso"))
+                else if (!Path.GetFileName(files[0]).Contains(".iso"))
                 {
+                    FileNameLabel.Text = string.Empty;
                     FileNameLabel2.Foreground = Brushes.Red;
-                    FileNameLabel2.Text = "This does not seem to be an iso file. Please use an iso file";
-                    LinkText.Text = String.Empty;
-                }
-                else if (CheckMD5(md5) == "invalid")
-                {
-                    FileNameLabel.Foreground = Brushes.Red;
-                    FileNameLabel.Text = "This iso file seems to be modified.  Please use a completely vanilla NTSC 1.02 iso.";
-                    FileNameLabel2.Foreground = Brushes.Red;
-                    FileNameLabel2.Text = "(This includes any skins or visual mods, which also interfere with the patch.)";
-                    LinkText.Text = String.Empty;
-                }
-                else if (CheckMD5(md5) == "nkit")
-                {
-                    FileNameLabel.Foreground = Brushes.Red;
-                    FileNameLabel.Text = "This application cannot process nkit compressed iso files.";
-                    FileNameLabel2.Foreground = Brushes.Red;
-                    FileNameLabel2.Text = "Please click the link below for a guide on how to decompress it.";
-                    LinkText.Text = "Guide for NKit decompression";
+                    FileNameLabel2.Text = "This does not seem to be an iso file. Please use an iso file.";
+                    LinkText.Text = string.Empty;
                 }
                 else
                 {
-                    if (BeyondRadio.IsChecked == true)
+                    FileNameLabel.Text = string.Empty;
+                    FileNameLabel2.Foreground = Brushes.Yellow;
+                    FileNameLabel2.Text = "Checking iso file...";
+                    worker.DoWork += delegate (object s, DoWorkEventArgs args)
                     {
-                        PreviewImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/beyond_preview.png"));
-                        BannerImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/beyond_banner.png"));
-                        VersionInfo.Text = "The standard version of Beyond Melee. All the great new features right in Melee.";
-                    }
-                    else if (DietRadio.IsChecked == true)
+                        string path = (string)args.Argument;
+                        args.Result = GetMD5(path);
+                    };
+
+                    worker.RunWorkerCompleted += delegate (object s, RunWorkerCompletedEventArgs args)
                     {
-                        PreviewImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/diet_preview.png"));
-                        BannerImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/diet_banner.png"));
-                        VersionInfo.Text = "Diet Beyond Melee is a lower quality version of Beyond Melee made to run on lower end hardware, like Diet Melee.";
-                    }
-                    //Removes old text and changes colors to green
-                    FileNameLabel.Foreground = Brushes.LightGreen;
-                    FileNameLabel.Text = "";
-                    FileNameLabel2.Foreground = Brushes.LightGreen;
-                    FileNameLabel2.Text = "";
-                    LinkText.Text = "";
+                        string result = (string)args.Result;
+                        CompareMD5(result, files[0]);
+                    };
 
-                    filePath = Path.GetFullPath(files[0]);
-
-                    FileNameLabel.Text = Path.GetFileName(files[0]);
+                    worker.RunWorkerAsync(files[0]);
                 }
             }
         }
@@ -97,8 +85,9 @@ namespace beyond_melee_installer
             {
                 if (BeyondRadio.IsChecked == true)
                 {
+                    //for some reason this doesnt work
                     FileNameLabel2.Foreground = Brushes.Yellow;
-                    FileNameLabel2.Text = "Patching...";
+                    FileNameLabel2.Text = "Running Patch...";
                     if (RunPatch("beyond_patch", filePath, $"Beyond-Melee-{versionNumber}"))
                     {
                         FileNameLabel2.Foreground = Brushes.LightGreen;
@@ -113,6 +102,9 @@ namespace beyond_melee_installer
                 }
                 else if (DietRadio.IsChecked == true)
                 {
+                    //for some reason this doesnt work
+                    FileNameLabel2.Foreground = Brushes.Yellow;
+                    FileNameLabel2.Text = "Running Patch...";
                     if (RunPatch("diet_patch", filePath, $"Diet-Beyond-Melee-{versionNumber}"))
                     {
                         FileNameLabel2.Foreground = Brushes.LightGreen;
@@ -239,7 +231,7 @@ namespace beyond_melee_installer
         {
             using var stream = File.OpenRead(filename);
             using var md5 = MD5.Create();
-            var hash =  md5.ComputeHash(stream);
+            var hash = md5.ComputeHash(stream);
             return BitConverter.ToString(hash).Replace("-", String.Empty).ToLowerInvariant();
         }
 
@@ -255,6 +247,51 @@ namespace beyond_melee_installer
                     return "invalid";
             }
 
+        }
+
+        private void CompareMD5(string hash, string filename)
+        {
+            if (CheckMD5(hash) == "invalid")
+            {
+                FileNameLabel.Foreground = Brushes.Red;
+                FileNameLabel.Text = "This iso file seems to be modified.  Please use a completely vanilla NTSC 1.02 iso.";
+                FileNameLabel2.Foreground = Brushes.Red;
+                FileNameLabel2.Text = "(This includes any skins or visual mods, which also interfere with the patch.)";
+                LinkText.Text = String.Empty;
+            }
+            else if (CheckMD5(hash) == "nkit")
+            {
+                FileNameLabel.Foreground = Brushes.Red;
+                FileNameLabel.Text = "This application cannot process nkit compressed iso files.";
+                FileNameLabel2.Foreground = Brushes.Red;
+                FileNameLabel2.Text = "Please click the link below for a guide on how to decompress it.";
+                LinkText.Text = "Guide for NKit decompression";
+            }
+            else
+            {
+                if (BeyondRadio.IsChecked == true)
+                {
+                    PreviewImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/beyond_preview.png"));
+                    BannerImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/beyond_banner.png"));
+                    VersionInfo.Text = "The standard version of Beyond Melee. All the great new features right in Melee.";
+                }
+                else if (DietRadio.IsChecked == true)
+                {
+                    PreviewImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/diet_preview.png"));
+                    BannerImage.Source = new BitmapImage(new Uri("pack://application:,,,/Images/diet_banner.png"));
+                    VersionInfo.Text = "Diet Beyond Melee is a lower quality version of Beyond Melee made to run on lower end hardware, like Diet Melee.";
+                }
+                //Removes old text and changes colors to green
+                FileNameLabel.Foreground = Brushes.LightGreen;
+                FileNameLabel.Text = "";
+                FileNameLabel2.Foreground = Brushes.LightGreen;
+                FileNameLabel2.Text = "";
+                LinkText.Text = "";
+
+                filePath = Path.GetFullPath(filename);
+
+                FileNameLabel.Text = Path.GetFileName(filename);
+            }
         }
     }
 }

--- a/beyond-melee-installer/beyond-melee-installer.csproj
+++ b/beyond-melee-installer/beyond-melee-installer.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
 	<ApplicationIcon>bm.ico</ApplicationIcon>
 	<AssemblyName>beyond-melee-patcher</AssemblyName>
-	<Version>0.1.2-offline</Version>
+	<Version>0.2.0-offline</Version>
 	<Authors>Cynthetic</Authors>
 	<Company>Beyond Melee Team</Company>
 	<PublishTrimmed>True</PublishTrimmed>


### PR DESCRIPTION
The installer will now actually check for an MD5 hash to see if it is the proper version of Melee 1.02 NTSC, and also will check against the nkit hash to check for the nkit version.  It will also now check for other things without having to run the cumbersome hash function, like checking to see if it is an iso file, as well as checking to make sure only 1 file was dropped on the window, since it cannot support multiple files dropped on the window. (technically it can, as long as the first file imported is the iso, but we cant really check for that without wasting time and processing power, so we just tell users to drop only one file)